### PR TITLE
Add OPIK_CC_THREAD_ID env var for trace thread grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This creates `~/.opik.config` with your API URL, key, and workspace.
 ```bash
 export OPIK_CC_PROJECT="my-project"         # Project name (default: claude-code)
 export OPIK_CC_TRUNCATE_FIELDS="false"      # Don't truncate large fields
+export OPIK_CC_THREAD_ID="my-thread-123"   # Group traces into an Opik thread
 ```
 
 All plugin env vars use the `OPIK_CC_` prefix to avoid conflicts with standard Opik SDK variables.

--- a/src/config.go
+++ b/src/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Enabled       bool
 	ParentTraceID string
 	RootSpanID    string
+	ThreadID      string
 }
 
 const truncateMsg = "[ TRUNCATED -- set OPIK_CC_TRUNCATE_FIELDS=false ]"
@@ -47,6 +48,7 @@ func LoadConfig() (*Config, error) {
 		Enabled:       tracing.enabled,
 		ParentTraceID: os.Getenv("OPIK_CC_PARENT_TRACE_ID"),
 		RootSpanID:    os.Getenv("OPIK_CC_ROOT_SPAN_ID"),
+		ThreadID:      os.Getenv("OPIK_CC_THREAD_ID"),
 	}
 
 	if proj := getEnvOrConfig("OPIK_CC_PROJECT", fileConfig, "project_name"); proj != "" {

--- a/src/main.go
+++ b/src/main.go
@@ -108,12 +108,16 @@ func onPrompt() {
 
 	// Only create new trace if not using parent trace
 	if config.ParentTraceID == "" {
+		threadID := input.SessionID
+		if config.ThreadID != "" {
+			threadID = config.ThreadID
+		}
 		trace := Trace{
 			ID:          traceID,
 			Name:        "claude-code",
 			StartTime:   ts,
 			ProjectName: config.Project,
-			ThreadID:    input.SessionID,
+			ThreadID:    threadID,
 			Tags:        []string{"claude-code"},
 			Input:       map[string]string{"text": input.Prompt},
 		}


### PR DESCRIPTION
## Summary
- Adds `OPIK_CC_THREAD_ID` environment variable that lets users group traces into an Opik thread
- When set, overrides the default behavior of using the Claude Code session ID as the thread ID
- When unset, behavior is unchanged (session ID is used as thread ID)

## Changes
- **src/config.go**: Added `ThreadID` field to `Config`, reads from `OPIK_CC_THREAD_ID`
- **src/main.go**: Uses `config.ThreadID` (if set) instead of `input.SessionID` for the trace's thread ID
- **README.md**: Documents the new env var in the optional configuration section

## Test plan
- [ ] Set `OPIK_CC_THREAD_ID=test-thread` and verify traces are created with that thread ID
- [ ] Unset `OPIK_CC_THREAD_ID` and verify traces still use the session ID as thread ID
- [ ] Verify traces with the same thread ID appear grouped in the Opik UI