### PR TITLE
[OPIK-5661][CLAUDE SKILL] The /instrument command within Claude introduce opik.configure(project_name="airline-service-agent") that breaks user code

### DIFF
--- a/skills/opik/SKILL.md
+++ b/skills/opik/SKILL.md
@@ -107,10 +107,10 @@ track_adk_agent_recursive(agent, opik_tracer)
 
 ## Detailed References
 
-| Topic | Reference File |
-|-------|----------------|
-| Python SDK (decorators, context, async, distributed tracing, configure) | `references/tracing-python.md` |
-| TypeScript SDK (client, decorators, framework integrations) | `references/tracing-typescript.md` |
-| REST API (HTTP endpoints, authentication) | `references/tracing-rest-api.md` |
-| All integrations with code snippets | `references/integrations.md` |
-| Core concepts (traces, spans, threads, metadata, feedback) | `references/observability.md` |
+| Topic                                                                       | Reference File |
+|-----------------------------------------------------------------------------|----------------|
+| Python SDK (decorators, context, async, distributed tracing, configuration) | `references/tracing-python.md` |
+| TypeScript SDK (client, decorators, framework integrations)                 | `references/tracing-typescript.md` |
+| REST API (HTTP endpoints, authentication)                                   | `references/tracing-rest-api.md` |
+| All integrations with code snippets                                         | `references/integrations.md` |
+| Core concepts (traces, spans, threads, metadata, feedback)                  | `references/observability.md` |

--- a/skills/opik/SKILL.md
+++ b/skills/opik/SKILL.md
@@ -109,7 +109,7 @@ track_adk_agent_recursive(agent, opik_tracer)
 
 | Topic | Reference File |
 |-------|----------------|
-| Python SDK (decorators, context, async, distributed tracing) | `references/tracing-python.md` |
+| Python SDK (decorators, context, async, distributed tracing, configure) | `references/tracing-python.md` |
 | TypeScript SDK (client, decorators, framework integrations) | `references/tracing-typescript.md` |
 | REST API (HTTP endpoints, authentication) | `references/tracing-rest-api.md` |
 | All integrations with code snippets | `references/integrations.md` |

--- a/skills/opik/references/tracing-python.md
+++ b/skills/opik/references/tracing-python.md
@@ -9,6 +9,32 @@ pip install opik
 opik configure  # Interactive setup
 ```
 
+Or configure programmatically:
+
+```python
+# Signature:
+# opik.configure(
+#     api_key: Optional[str] = None,
+#     workspace: Optional[str] = None,
+#     url: Optional[str] = None,          # Deprecated: use url_override instead
+#     url_override: Optional[str] = None,
+#     use_local: bool = False,
+#     force: bool = False,
+#     automatic_approvals: bool = False,
+# ) -> None
+
+import opik
+
+# Opik Cloud
+opik.configure(api_key="your-api-key", workspace="your-workspace")
+
+# Local deployment
+opik.configure(url_override="http://localhost:5173/api", use_local=True)
+
+# Force overwrite existing config
+opik.configure(api_key="new-key", force=True)
+```
+
 Or set environment variables:
 ```bash
 export OPIK_API_KEY="your-api-key"


### PR DESCRIPTION
## Summary

Added `opik.configure()` API reference to the Python SDK documentation.

## Files Modified

### `skills/opik/SKILL.md`

Updated the Detailed References table to mention `configure` in the Python SDK entry, so users can discover the configuration API when scanning available topics.

### `skills/opik/references/tracing-python.md`

Added a new `opik.configure()` section under **Installation & Configuration** with:

- Full function signature including all parameters (`api_key`, `workspace`, `url` (deprecated), `url_override`, `use_local`, `force`, `automatic_approvals`)
- Usage examples:
  - Opik Cloud setup
  - Local deployment setup
  - Force-overwrite of existing config

## JIRA

https://comet-ml.atlassian.net/browse/OPIK-5661