### PR TITLE
feat: plugin-scoped workspace & project overrides (cc_workspace / cc_project)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,21 @@ export OPIK_CC_TRUNCATE_FIELDS="false"      # Don't truncate large fields
 
 All plugin env vars use the `OPIK_CC_` prefix to avoid conflicts with standard Opik SDK variables.
 
-`OPIK_CC_WORKSPACE` lets you send Claude Code traces to a different workspace than the rest
-of your Opik setup, without touching the global `OPIK_WORKSPACE` / `~/.opik.config` workspace
-used by the Opik SDK. It can also be set in `~/.opik.config` via the `cc_workspace` key:
+`OPIK_CC_WORKSPACE` and `OPIK_CC_PROJECT` let you send Claude Code traces to a different
+workspace/project than the rest of your Opik setup, without touching the global
+`OPIK_WORKSPACE` / `project_name` in `~/.opik.config` used by the Opik SDK. Both can also be
+set in `~/.opik.config` via the plugin-scoped `cc_workspace` and `cc_project` keys:
 
 ```ini
 [opik]
 workspace = my-sdk-workspace      # used by the Opik SDK
+project_name = my-sdk-project     # used by the Opik SDK
 cc_workspace = my-cc-workspace    # used only by the Claude Code plugin
+cc_project = my-cc-project         # used only by the Claude Code plugin
 ```
+
+> Note: for backward compatibility, if `cc_project` is not set the plugin still falls back to
+> the shared `project_name` key.
 
 ### External Trace Linking
 

--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ set in `~/.opik.config` via the plugin-scoped `cc_workspace` and `cc_project` ke
 [opik]
 workspace = my-sdk-workspace      # used by the Opik SDK
 project_name = my-sdk-project     # used by the Opik SDK
-cc_workspace = my-cc-workspace    # used only by the Claude Code plugin
-cc_project = my-cc-project         # used only by the Claude Code plugin
+cc_workspace = my-cc-workspace        # used only by the Claude Code plugin
+cc_project_name = my-cc-project       # used only by the Claude Code plugin
 ```
 
-> Note: for backward compatibility, if `cc_project` is not set the plugin still falls back to
-> the shared `project_name` key.
+> Note: for backward compatibility, if `cc_project_name` is not set the plugin still falls back
+> to the shared `project_name` key.
 
 ### External Trace Linking
 

--- a/README.md
+++ b/README.md
@@ -57,10 +57,21 @@ This creates `~/.opik.config` with your API URL, key, and workspace.
 
 ```bash
 export OPIK_CC_PROJECT="my-project"         # Project name (default: claude-code)
+export OPIK_CC_WORKSPACE="my-workspace"     # Workspace override (default: OPIK_WORKSPACE / ~/.opik.config)
 export OPIK_CC_TRUNCATE_FIELDS="false"      # Don't truncate large fields
 ```
 
 All plugin env vars use the `OPIK_CC_` prefix to avoid conflicts with standard Opik SDK variables.
+
+`OPIK_CC_WORKSPACE` lets you send Claude Code traces to a different workspace than the rest
+of your Opik setup, without touching the global `OPIK_WORKSPACE` / `~/.opik.config` workspace
+used by the Opik SDK. It can also be set in `~/.opik.config` via the `cc_workspace` key:
+
+```ini
+[opik]
+workspace = my-sdk-workspace      # used by the Opik SDK
+cc_workspace = my-cc-workspace    # used only by the Claude Code plugin
+```
 
 ### External Trace Linking
 

--- a/src/config.go
+++ b/src/config.go
@@ -51,6 +51,12 @@ func LoadConfig() (*Config, error) {
 		cfg.Project = proj
 	}
 
+	// Allow overriding the workspace for the Claude Code plugin only, without
+	// affecting the global OPIK_WORKSPACE / ~/.opik.config used by the Opik SDK.
+	if ws := getEnvOrConfig("OPIK_CC_WORKSPACE", fileConfig, "cc_workspace"); ws != "" {
+		cfg.Workspace = ws
+	}
+
 	return cfg, nil
 }
 

--- a/src/config.go
+++ b/src/config.go
@@ -47,7 +47,12 @@ func LoadConfig() (*Config, error) {
 		RootSpanID:    os.Getenv("OPIK_CC_ROOT_SPAN_ID"),
 	}
 
-	if proj := getEnvOrConfig("OPIK_CC_PROJECT", fileConfig, "project_name"); proj != "" {
+	// OPIK_CC_PROJECT / cc_project are plugin-scoped and don't affect the Opik
+	// SDK. project_name is kept as a fallback for backward compatibility, but it
+	// is shared with the Opik SDK config in ~/.opik.config.
+	if proj := getEnvOrConfig("OPIK_CC_PROJECT", fileConfig, "cc_project"); proj != "" {
+		cfg.Project = proj
+	} else if proj := fileConfig["project_name"]; proj != "" {
 		cfg.Project = proj
 	}
 

--- a/src/config.go
+++ b/src/config.go
@@ -50,7 +50,7 @@ func LoadConfig() (*Config, error) {
 	// OPIK_CC_PROJECT / cc_project are plugin-scoped and don't affect the Opik
 	// SDK. project_name is kept as a fallback for backward compatibility, but it
 	// is shared with the Opik SDK config in ~/.opik.config.
-	if proj := getEnvOrConfig("OPIK_CC_PROJECT", fileConfig, "cc_project"); proj != "" {
+	if proj := getEnvOrConfig("OPIK_CC_PROJECT", fileConfig, "cc_project_name"); proj != "" {
 		cfg.Project = proj
 	} else if proj := fileConfig["project_name"]; proj != "" {
 		cfg.Project = proj


### PR DESCRIPTION
## Summary

Adds plugin-scoped **workspace** and **project** overrides so Claude Code traces can be sent to a different Opik workspace/project than the rest of a user's Opik setup.

Today the logger resolves workspace from the **standard global** `OPIK_WORKSPACE` / `~/.opik.config` `workspace`, and project from `OPIK_CC_PROJECT` / the shared `project_name` key. Because `workspace` and `project_name` are the same keys the Opik SDK reads, the only way to redirect Claude Code traces was to edit those global values — which also moves the SDK (and everything else) to that workspace/project.

This adds plugin-scoped equivalents, mirroring the existing `OPIK_CC_*` convention:

| Setting | Env var | `~/.opik.config` key | Fallback |
|---|---|---|---|
| Workspace | `OPIK_CC_WORKSPACE` | `cc_workspace` | `OPIK_WORKSPACE` / `workspace` |
| Project | `OPIK_CC_PROJECT` | `cc_project_name` | `project_name` (shared, kept for back-compat) |

When the plugin-scoped value is set it overrides the resolved value **for the logger only**; otherwise behavior is unchanged.

## Example

```ini
[opik]
workspace = my-sdk-workspace          # used by the Opik SDK
project_name = my-sdk-project         # used by the Opik SDK
cc_workspace = my-cc-workspace        # used only by the Claude Code plugin
cc_project_name = my-cc-project       # used only by the Claude Code plugin
```

or via env:

```bash
export OPIK_CC_WORKSPACE="my-cc-workspace"
export OPIK_CC_PROJECT="my-cc-project"
```

## Changes

- `src/config.go`: apply `OPIK_CC_WORKSPACE` / `cc_workspace` override; add `cc_project_name` config key with `project_name` fallback
- `README.md`: document the new env vars and config keys

## Backward compatibility

Fully backward compatible — `project_name` still works as a fallback when `cc_project_name` is unset, and workspace resolution is unchanged when `cc_workspace` is unset.

## Testing

- `go vet ./src/` — clean
- `go build ./src` — clean
- Binaries intentionally not rebuilt here; the Build workflow regenerates `bin/` on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)