### PR TITLE
feat: implement user-level (global) tracing toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,15 +121,22 @@ Enable/disable automatic tracing of your Claude Code sessions to Opik.
 /opik:trace-claude-code start                 # Enable tracing for this project
 /opik:trace-claude-code start --debug         # Enable tracing + debug logging
 /opik:trace-claude-code stop                  # Disable tracing for this project
-/opik:trace-claude-code status                # Check current tracing status
+/opik:trace-claude-code status                # Check project + global + effective state
 
 /opik:trace-claude-code start --global        # Enable tracing for all projects
 /opik:trace-claude-code stop --global         # Disable tracing globally
 ```
 
-Tracing state is stored in `.claude/.opik-tracing-enabled` (project) or `~/.claude/.opik-tracing-enabled` (global). Project settings take precedence.
+Tracing state is stored in `.claude/.opik-tracing-enabled` (project) or `~/.claude/.opik-tracing-enabled` (global). Resolution order (first match wins):
 
-**Note:** Restart Claude Code sessions for changes to take effect.
+1. Project file containing `off`/`disabled` → **disabled** (opt a single project out of a global enable)
+2. Project file present → **enabled** (`debug` content also enables debug logging)
+3. Global file present → **enabled** (same content rules)
+4. Neither → **disabled**
+
+So the project setting always takes precedence over the global one. Running `stop` in a project while global tracing is on writes the `off` opt-out for that project rather than removing the global enable.
+
+**Note:** Changes take effect immediately for new conversation turns (no restart needed).
 
 ### `/opik:instrument` - Add Observability to Your Code
 

--- a/commands/trace-claude-code.md
+++ b/commands/trace-claude-code.md
@@ -1,6 +1,6 @@
 ---
 description: Control Opik tracing for your Claude Code sessions
-argument-hint: [start|stop|status] [--debug]
+argument-hint: [start|stop|status] [--global] [--debug]
 allowed-tools:
   - Bash
   - Read
@@ -16,37 +16,59 @@ Based on the user's request: **$ARGUMENTS**
 
 ## Scope
 
-Tracing is configured per-project via `.claude/.opik-tracing-enabled` in the project directory.
+Tracing can be enabled at two levels:
+
+- **Project** (default): `.claude/.opik-tracing-enabled` in the current project directory.
+- **Global** (`--global` flag): `~/.claude/.opik-tracing-enabled`, which enables tracing for every project.
+
+The project-level file takes precedence over the global one, so a single project can override the global setting (including turning tracing **off** while it is enabled globally).
 
 ## File Semantics
 
-- File exists → tracing enabled
+For both the project and global files:
+
+- File contains `off` or `disabled` → tracing disabled (used to opt a project out of a global enable)
 - File contains `debug` → tracing + debug logging
-- File doesn't exist → tracing disabled
+- File exists with any other content (or empty) → tracing enabled
+- File doesn't exist → no opinion at this level (fall through to the next level)
+
+Resolution order (first match wins): project `off` → project enabled → global enabled → disabled.
 
 ## Actions
 
+Determine the target file from the flags:
+- If `--global` (or `--user`) is present, target is `~/.claude/.opik-tracing-enabled`.
+- Otherwise, target is `.claude/.opik-tracing-enabled` in the current directory.
+
 **If the request contains "start":**
-- Create `.claude/` directory if needed with `mkdir -p`
-- If `--debug` is present, write `debug` to `.claude/.opik-tracing-enabled`
-- Otherwise, touch/create the file (content doesn't matter)
-- Confirm: "Opik session tracing enabled for this project. Takes effect immediately for new conversation turns."
+- Create the parent `.claude/` directory if needed with `mkdir -p`.
+- If `--debug` is present, write `debug` to the target file.
+- Otherwise, write an empty file / `touch` the target file (content doesn't matter).
+- Confirm scope: "Opik session tracing enabled \[globally for all projects | for this project]. Takes effect immediately for new conversation turns."
 
 **If the request contains "stop":**
-- Delete `.claude/.opik-tracing-enabled`
-- Confirm: "Opik session tracing disabled for this project."
+- If `--global` is present: delete `~/.claude/.opik-tracing-enabled`. Confirm: "Opik session tracing disabled globally."
+- Otherwise (project stop):
+  - Check whether the global file `~/.claude/.opik-tracing-enabled` exists and is not itself `off`/`disabled`.
+  - If global tracing is active, write `off` to `.claude/.opik-tracing-enabled` (an explicit opt-out that overrides the global enable), and confirm: "Opik session tracing disabled for this project (overriding the global setting)."
+  - If global tracing is not active, delete `.claude/.opik-tracing-enabled`, and confirm: "Opik session tracing disabled for this project."
 
 **If the request is "status":**
-1. Check if `.claude/.opik-tracing-enabled` exists in current directory
-2. Report state: "Tracing: [enabled/enabled+debug/disabled]"
+1. Read the project file `.claude/.opik-tracing-enabled` (if any) and the global file `~/.claude/.opik-tracing-enabled` (if any), interpreting each via the File Semantics above.
+2. Report each level: "Project: \[enabled | enabled+debug | opt-out (off) | not set]" and "Global: \[enabled | enabled+debug | not set]".
+3. Report the resolved effective state using the resolution order: "Effective: \[enabled | enabled+debug | disabled]".
 
 ## Examples
 
 ```
-/opik:trace-claude-code start          # Enable session tracing for this project
-/opik:trace-claude-code start --debug  # Enable tracing + debug logging
-/opik:trace-claude-code stop           # Disable tracing for this project
-/opik:trace-claude-code status         # Check current state
+/opik:trace-claude-code start                 # Enable session tracing for this project
+/opik:trace-claude-code start --debug         # Enable tracing + debug logging for this project
+/opik:trace-claude-code stop                  # Disable tracing for this project
+/opik:trace-claude-code status                # Check project + global + effective state
+
+/opik:trace-claude-code start --global        # Enable tracing for ALL projects
+/opik:trace-claude-code start --global --debug # Enable tracing + debug for ALL projects
+/opik:trace-claude-code stop --global         # Disable global tracing
 ```
 
 ## What This Does

--- a/src/config.go
+++ b/src/config.go
@@ -88,19 +88,31 @@ type tracingState struct {
 }
 
 func checkTracingFile(path string) (tracingState, bool) {
-	if _, err := os.Stat(path); err == nil {
-		state := tracingState{enabled: true}
-		if data, err := os.ReadFile(path); err == nil {
-			state.debug = strings.TrimSpace(string(data)) == "debug"
-		}
-		return state, true
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return tracingState{}, false
 	}
-	return tracingState{}, false
+	content := strings.TrimSpace(string(data))
+	// Explicit opt-out: lets a single project turn tracing off even when it is
+	// enabled globally via ~/.claude/.opik-tracing-enabled.
+	if content == "off" || content == "disabled" {
+		return tracingState{enabled: false}, true
+	}
+	return tracingState{enabled: true, debug: content == "debug"}, true
 }
 
 func getTracingState() tracingState {
+	// Project-level marker takes precedence, including an explicit "off" opt-out
+	// that wins over a global enable.
 	if projectDir := os.Getenv("CLAUDE_PROJECT_DIR"); projectDir != "" {
 		if state, found := checkTracingFile(filepath.Join(projectDir, ".claude", ".opik-tracing-enabled")); found {
+			return state
+		}
+	}
+
+	// Fall back to a user-level marker so tracing can be enabled for all projects.
+	if homeDir, err := os.UserHomeDir(); err == nil && homeDir != "" {
+		if state, found := checkTracingFile(filepath.Join(homeDir, ".claude", ".opik-tracing-enabled")); found {
 			return state
 		}
 	}


### PR DESCRIPTION
## Summary

Implements the **global / user-level tracing toggle** that the README already advertises but that was never wired up.

`README.md` documents `--global` and a `~/.claude/.opik-tracing-enabled` marker with *"Project settings take precedence"*, but `getTracingState()` only ever checked `CLAUDE_PROJECT_DIR/.claude/.opik-tracing-enabled`, and the `/opik:trace-claude-code` command only supported the project level. So the feature was documented but non-functional — you had to run `start` in every project separately.

## Changes

- **`src/config.go`** — `getTracingState()` now falls back to `~/.claude/.opik-tracing-enabled` when there is no project-level marker, so tracing can be enabled once for all projects.
- **Per-project opt-out** — a project marker containing `off` (or `disabled`) forces tracing **off** even when it is enabled globally. This is needed because, once a global default exists, "file absent" means "inherit global" rather than "off" — so an explicit opt-out is required to silence a single repo.
- **`commands/trace-claude-code.md`** — implements `--global`/`--user`, the `off` opt-out, a two-level `status` (project + global + effective), and a smart `stop` that writes the `off` opt-out when global tracing is active (instead of deleting the project file, which would leave it inherited-on).
- **`README.md`** — documents the full resolution order and the `off` opt-out.

## Resolution order (first match wins)

| Order | Check | Result |
|---|---|---|
| 1 | Project file contains `off`/`disabled` | **disabled** (opt-out) |
| 2 | Project file present | enabled (+debug if content `debug`) |
| 3 | Global `~/.claude/.opik-tracing-enabled` present | enabled (+debug if content `debug`) |
| 4 | _neither_ | disabled |

## UX

```
/opik:trace-claude-code start --global   # trace every project
/opik:trace-claude-code stop             # opt THIS project out (writes `off` when global is on)
/opik:trace-claude-code status           # Project: … | Global: … | Effective: …
```

## Backward compatibility

Fully compatible — with no global file and no `off` content, behavior is byte-for-byte identical to today (project file present = enabled).

## Testing

- `go vet ./src/` + `go build ./src` — clean
- End-to-end against a local capture server, verifying the resolution order:

  | Case | Setup | Expected | Result |
  |---|---|---|---|
  | A | nothing set | no trace | ✅ |
  | B | global file only | trace | ✅ |
  | C | global on + project `off` | no trace | ✅ |
  | D | project file present | trace | ✅ |

- Binaries intentionally not rebuilt here; the Build workflow regenerates `bin/` on merge to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)