### PR TITLE
chore: bump plugin version to 0.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "opik",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "description": "LLM observability tooling for agent development and Claude Code",
   "author": {
     "name": "Comet ML",


### PR DESCRIPTION
Bumps `.claude-plugin/plugin.json` version `0.1.0` → `0.3.0`. Single-line change, no feature work.

Once merged to `main`, cut the GitHub release/tag `0.3.0` from main, then refresh clients with `/plugin marketplace update opik`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)