### PR TITLE
ci: fix binary drift — releases now build + commit binaries atomically

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,15 +1,17 @@
 name: Build
 
+# PR check only: confirms the Go source compiles for every target platform.
+# Binaries are NOT committed here — they are rebuilt and committed by the
+# Release workflow (release.yml) so bin/ and the version always move together.
 on:
-  push:
-    branches: [main]
+  pull_request:
     paths:
       - 'src/**'
       - 'go.mod'
       - 'Makefile'
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   build:
@@ -20,21 +22,10 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.21.13'
 
-      - name: Build binaries
+      - name: Vet
+        run: go vet ./src
+
+      - name: Build binaries (compile check)
         run: make build
-
-      - name: Check for changes
-        id: changes
-        run: |
-          git diff --quiet bin/ || echo "changed=true" >> $GITHUB_OUTPUT
-
-      - name: Commit binaries
-        if: steps.changes.outputs.changed == 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add bin/
-          git commit -m "Build: update binaries [skip ci]"
-          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,29 +1,71 @@
 name: Release
 
+# Manually triggered from the Actions tab (or `gh workflow run release.yml -f version=0.3.1`).
+# Bumps the version, rebuilds binaries, commits both to main, tags, and publishes
+# the GitHub release in one atomic step so bin/ and the version never drift.
 on:
-  release:
-    types: [created]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version, e.g. 0.3.1 (no leading v)'
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          # PAT (org secret) so this job can push the release commit to the
+          # protected main branch. The default GITHUB_TOKEN / github-actions[bot]
+          # cannot bypass branch protection.
+          token: ${{ secrets.GH_PAT_TO_ACCESS_GITHUB_API }}
+
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Invalid version '${{ inputs.version }}'. Expected X.Y.Z"
+            exit 1
+          fi
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          # Pinned to an exact patch so binaries are reproducible across runs.
+          go-version: '1.21.13'
+
+      - name: Bump version in plugin.json
+        run: |
+          tmp=$(mktemp)
+          jq --arg v "${{ inputs.version }}" '.version = $v' .claude-plugin/plugin.json > "$tmp"
+          mv "$tmp" .claude-plugin/plugin.json
+          echo "plugin.json now at version ${{ inputs.version }}"
 
       - name: Build binaries
         run: make build
 
-      - name: Upload binaries to release
+      - name: Commit, tag, and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions@comet.com"
+          git add .claude-plugin/plugin.json bin/
+          git commit -m "chore: release v${{ inputs.version }}"
+          git tag -a "${{ inputs.version }}" -m "Release v${{ inputs.version }}"
+          git push origin main
+          git push origin "${{ inputs.version }}"
+
+      - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.version }}
+          name: ${{ inputs.version }}
+          generate_release_notes: true
           files: |
             bin/opik-logger-darwin-arm64
             bin/opik-logger-darwin-amd64

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ build:
 		os=$${platform%/*}; arch=$${platform#*/}; \
 		ext=""; [ "$$os" = "windows" ] && ext=".exe"; \
 		echo "Building $$os/$$arch..."; \
-		GOOS=$$os GOARCH=$$arch go build -ldflags="-s -w" -o bin/$(BINARY)-$$os-$$arch$$ext ./src; \
+		GOOS=$$os GOARCH=$$arch go build -trimpath -ldflags="-s -w" -o bin/$(BINARY)-$$os-$$arch$$ext ./src; \
 	done
 	@echo "Done. Binaries in bin/"
 
 build-local:
 	@mkdir -p bin
-	@go build -o bin/$(BINARY)-$$(uname -s | tr '[:upper:]' '[:lower:]')-$$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') ./src
+	@go build -trimpath -o bin/$(BINARY)-$$(uname -s | tr '[:upper:]' '[:lower:]')-$$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/') ./src
 	@echo "Built local binary"
 
 clean:


### PR DESCRIPTION
## What this PR does

Changes how the plugin's Go binaries get built and released, so a release can never again ship a binary that's out of date with the source.

## Why

The 0.3.0 release shipped binaries that were built back in March — before the `cc_workspace` feature (and other June changes) existed. That's why Claude Code traces were going to the wrong Opik workspace even though the config and source code were both correct.

The reason the binaries were stale: CI used to rebuild them on every push to `main` and commit them straight back to `main`. But `main` is now a protected branch that requires pull requests, so CI's direct push got rejected every time:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

CI didn't fail loudly — the binaries just silently never updated, and the next release picked up the old ones.

This matters because installing the plugin pulls the binaries committed in the repo (`main`), so if those are stale, every user gets stale binaries.

## The fix

- **`release.yml`** — now a single button you trigger manually (Actions → Release, or `gh workflow run release.yml -f version=0.3.1`). It bumps the version, rebuilds the binaries, and commits both together, then tags and publishes the release. Version and binaries always move as one, so they can't drift apart. It pushes to `main` using a PAT that's allowed past branch protection (same approach the main `opik` repo uses).
- **`build.yml`** — simplified to a PR check that just confirms the code still compiles (`go vet` + `make build`). It no longer tries to push to `main`.
- **`Makefile`** — added `-trimpath` so builds are reproducible regardless of which machine runs them.

## How to cut a release after this merges

Actions tab → **Release** → Run workflow → enter the version (e.g. `0.3.1`), or:

```
gh workflow run release.yml -f version=0.3.1
```

## One-time setup needed from an org admin

The release workflow can only push to `main` if:
1. The `GH_PAT_TO_ACCESS_GITHUB_API` org secret is shared with this repo.
2. The PAT's owner is on the bypass list for the `main` branch rule.

(The same PAT already pushes to `main` in the `opik` repo, so this likely already works org-wide.)

## Good to know

Binaries are now rebuilt only at release time. So after merging meaningful source changes, cut a release — otherwise `main` will temporarily serve binaries that lag the source to anyone installing in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)