### PR TITLE
Move deterministic cc.* metrics into trace metadata

### DIFF
--- a/src/api.go
+++ b/src/api.go
@@ -33,6 +33,33 @@ func (a *API) Put(endpoint string, data interface{}) error {
 	return a.request("PUT", endpoint, data)
 }
 
+// Get fetches a JSON endpoint and unmarshals the response into out.
+func (a *API) Get(endpoint string, out interface{}) error {
+	req, err := http.NewRequest("GET", a.config.URL+endpoint, nil)
+	if err != nil {
+		return fmt.Errorf("GET %s: build request: %w", endpoint, err)
+	}
+	if a.config.APIKey != "" {
+		req.Header.Set("Authorization", a.config.APIKey)
+	}
+	if a.config.Workspace != "" {
+		req.Header.Set("Comet-Workspace", a.config.Workspace)
+	}
+	resp, err := a.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("GET %s: %w", endpoint, err)
+	}
+	defer func() {
+		io.Copy(io.Discard, resp.Body)
+		resp.Body.Close()
+	}()
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("GET %s: %d %s", endpoint, resp.StatusCode, body)
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
+}
+
 func (a *API) request(method, endpoint string, data interface{}) error {
 	jsonData, err := json.Marshal(data)
 	if err != nil {

--- a/src/identity.go
+++ b/src/identity.go
@@ -7,7 +7,8 @@ import (
 )
 
 // ClaudeIdentity is Claude Code's OAuth identity, read from ~/.claude.json.
-// Used as the source of truth for who is running this session.
+// Used as the source of truth for who is running this session — preferred
+// over git config because it gives a stable user UUID + org primitive.
 type ClaudeIdentity struct {
 	UserUUID    string `json:"user_uuid,omitempty"`
 	Email       string `json:"email,omitempty"`

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -171,27 +171,9 @@ func captureCwdAndHead() (cwd, head string) {
 	return
 }
 
-// putScore PUTs a single feedback score onto a trace. Errors are logged and
-// swallowed — metric posting must never block trace flow.
-func putScore(traceID, name string, value float64, category string) {
-	body := map[string]interface{}{
-		"name":   name,
-		"value":  value,
-		"source": "sdk",
-	}
-	if category != "" {
-		if len(category) > 300 {
-			category = category[:300]
-		}
-		body["category_name"] = category
-	}
-	if err := api.Put("/traces/"+traceID+"/feedback-scores", body); err != nil {
-		debugLog("put_score %s=%v: %v", name, value, err)
-	}
-}
-
 // postTraceMetrics computes git-grounded metrics for the closing trace and
-// posts them as feedback scores. Cheap (~few hundred ms total).
+// merges them into trace.metadata.cc. Feedback scores stay reserved for
+// evaluative judgments — task_class and summary — written by other workers.
 func postTraceMetrics(state *State) {
 	cwd := state.Cwd
 	if cwd == "" {
@@ -201,7 +183,6 @@ func postTraceMetrics(state *State) {
 		debugLog("postTraceMetrics: no cwd")
 		return
 	}
-	// Bail if not a git working tree.
 	if git(cwd, "rev-parse", "--is-inside-work-tree") != "true" {
 		debugLog("postTraceMetrics: %s is not a git work tree", cwd)
 		return
@@ -211,32 +192,68 @@ func postTraceMetrics(state *State) {
 
 	repo := repoName(cwd)
 	branch := git(cwd, "branch", "--show-current")
+	// HEAD as of trace close; pairs with state.HeadSHAStart captured at onPrompt.
 	headEnd := git(cwd, "rev-parse", "HEAD")
 	commits, insC, delC := commitsBetween(cwd, state.HeadSHAStart, headEnd)
 	filesU, insU, delU := parseShortstat(git(cwd, "diff", "HEAD", "--shortstat"))
 
+	metrics := map[string]interface{}{
+		"commits_in_trace":  commits,
+		"lines_committed":   insC + delC,
+		"uncommitted_lines": insU + delU,
+		"uncommitted_files": filesU,
+		"files_authored":    len(agg.Files),
+		"lines_authored":    agg.LinesAuthored,
+		"lines_overwritten": agg.LinesOverwritten,
+	}
 	if repo != "" {
-		putScore(state.TraceID, "cc.repository", 1, repo)
+		metrics["repository"] = repo
 	}
 	if branch != "" {
-		putScore(state.TraceID, "cc.branch", 1, branch)
+		metrics["branch"] = branch
 	}
 	if state.HeadSHAStart != "" {
-		putScore(state.TraceID, "cc.head_sha_start", 1, shortSHA(state.HeadSHAStart))
+		metrics["head_sha_start"] = shortSHA(state.HeadSHAStart)
 	}
 	if headEnd != "" {
-		putScore(state.TraceID, "cc.head_sha_end", 1, shortSHA(headEnd))
+		metrics["head_sha_end"] = shortSHA(headEnd)
 	}
-	putScore(state.TraceID, "cc.commits_in_trace", float64(commits), "")
-	putScore(state.TraceID, "cc.lines_committed", float64(insC+delC), "")
-	putScore(state.TraceID, "cc.uncommitted_lines", float64(insU+delU), "")
-	putScore(state.TraceID, "cc.uncommitted_files", float64(filesU), "")
-	putScore(state.TraceID, "cc.files_authored", float64(len(agg.Files)), "")
-	putScore(state.TraceID, "cc.lines_authored", float64(agg.LinesAuthored), "")
-	putScore(state.TraceID, "cc.lines_overwritten", float64(agg.LinesOverwritten), "")
+
+	mergeMetadataCC(state.TraceID, metrics)
 
 	debugLog("metrics %s  repo=%s  branch=%s  commits=%d  +-=%d  uncommitted=%d  files=%d  authored=%d  overwritten=%d",
 		state.TraceID[:8], repo, branch, commits, insC+delC, insU+delU, len(agg.Files), agg.LinesAuthored, agg.LinesOverwritten)
+}
+
+// mergeMetadataCC reads the trace's current metadata, merges new keys into
+// the `cc` block (preserving identity already written at trace creation and
+// any non-cc metadata Opik may have added), and PATCHes the trace.
+func mergeMetadataCC(traceID string, addCC map[string]interface{}) {
+	var trace struct {
+		Metadata map[string]interface{} `json:"metadata"`
+	}
+	if err := api.Get("/traces/"+traceID, &trace); err != nil {
+		debugLog("mergeMetadataCC get: %v", err)
+		// Best-effort: still PATCH our keys under cc with no merge.
+		trace.Metadata = map[string]interface{}{}
+	}
+	if trace.Metadata == nil {
+		trace.Metadata = map[string]interface{}{}
+	}
+	existingCC, _ := trace.Metadata["cc"].(map[string]interface{})
+	if existingCC == nil {
+		existingCC = map[string]interface{}{}
+	}
+	for k, v := range addCC {
+		existingCC[k] = v
+	}
+	trace.Metadata["cc"] = existingCC
+	if err := api.Patch("/traces/"+traceID, map[string]interface{}{
+		"project_name": config.Project,
+		"metadata":     trace.Metadata,
+	}); err != nil {
+		debugLog("mergeMetadataCC patch: %v", err)
+	}
 }
 
 func shortSHA(sha string) string {


### PR DESCRIPTION
## Summary
Follow-up to #11. Moves all deterministic git-grounded metrics out of feedback scores and into `trace.metadata.cc`. Feedback scores are now reserved for evaluative judgments (`cc.summary`, `cc.task_class`) emitted by the LLM tagger.

## Why
After #11 we had a split surface: identity in `metadata.cc`, but the 11 git metrics as feedback scores. That conflated *observation* (counts, repo state, sha bounds) with *judgment* (categorical task type, narrative summary). It also let the LLM tagger fight with the Go hook over `cc.repository` — different writers, different shapes (`category_name="emitted"` vs the actual repo string).

Cleaner mental model:

| Surface | Contains |
|---|---|
| `metadata.cc` | All Claude-Code-specific observations the hook can measure deterministically |
| `feedback_scores` | LLM-tagger evaluations only — `cc.summary`, `cc.task_class` |

## What lands on `metadata.cc` now

Identity (set at trace creation, unchanged from #11):
- `user_email`, `user_uuid`, `user_display_name`, `org_uuid`, `org_name`

Git metrics (moved from feedback scores → merged at trace close):
- `repository`, `branch`, `head_sha_start`, `head_sha_end`
- `commits_in_trace`, `lines_committed`
- `uncommitted_lines`, `uncommitted_files`
- `files_authored`, `lines_authored`, `lines_overwritten`

## Merge strategy
`metadata` is a JsonNode — PATCH replaces it wholesale. To preserve identity (set at creation) and any non-`cc` metadata Opik adds (e.g. `providers`), `postTraceMetrics` now:
1. GETs the trace
2. Mutates `metadata.cc` with new git keys
3. PATCHes the full `metadata` back, with `project_name` included (Opik 409s without it)

## Test plan
- [x] Verified live: latest closing trace has 16 keys in `metadata.cc` (5 identity + 11 git), and `metadata.providers=["anthropic"]` survives the merge intact
- [x] Verified empty `feedback_scores` from the hook (only LLM tagger writes there now)
- [x] Reproduced 409 from the previous attempt, confirmed `project_name` in PATCH body fixes it
- [x] `make build` succeeds for all four target platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)