### PR TITLE
Org-wide tracing enable + per-user project templating via managed settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,64 @@ If you've cloned the repo locally, add it as a marketplace and install from ther
 
 **Important:** Restart any running Claude Code sessions after installation. Hooks only load when a session starts.
 
+### Enterprise Install (Managed Settings)
+
+For org-wide deployment, drop a [Claude Code managed-settings.json](https://code.claude.com/docs/en/settings) on every user's machine via your MDM. Managed settings override user/project settings and let an admin enable the plugin, point it at an org-owned Opik workspace, and route every user to their own project automatically.
+
+**Path on each platform:**
+
+| Platform | Path |
+|---|---|
+| macOS | `/Library/Application Support/ClaudeCode/managed-settings.json` |
+| Linux/WSL | `/etc/claude-code/managed-settings.json` |
+| Windows | `C:\Program Files\ClaudeCode\managed-settings.json` |
+
+**Example `managed-settings.json`:**
+
+```json
+{
+  "extraKnownMarketplaces": {
+    "opik": {
+      "source": {"source": "github", "repo": "comet-ml/opik-claude-code-plugin"},
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "opik@opik": true
+  },
+  "env": {
+    "OPIK_CC_TRACING_ENABLED": "true",
+    "OPIK_BASE_URL": "https://www.comet.com/opik/api",
+    "OPIK_CC_WORKSPACE": "your-org-cc-workspace",
+    "OPIK_API_KEY": "<workspace-scoped API key>",
+    "OPIK_CC_PROJECT": "cc-{username}"
+  }
+}
+```
+
+What each piece does:
+
+- `extraKnownMarketplaces` + `enabledPlugins` — registers the marketplace and force-enables the plugin for every user. Users see it as **managed** and can't disable it.
+- `OPIK_CC_TRACING_ENABLED=true` — turns tracing on for every session without users dropping per-project files. Individual projects can still opt out by writing `off` to `.claude/.opik-tracing-enabled`.
+- `OPIK_CC_WORKSPACE` — sends Claude Code traces to a dedicated workspace, isolated from any user's personal Opik work in `~/.opik.config`.
+- `OPIK_API_KEY` — the workspace-scoped key the hook uses to write traces. Treat this file as sensitive; the API key is shared with every machine it's deployed to. Provision a key with the minimum write scope on the CC workspace.
+- `OPIK_CC_PROJECT` — supports `{field}` tokens that expand from the user's Claude Code OAuth identity (read from `~/.claude.json`). So one config string routes every user to their own project.
+
+**Available `{field}` tokens:**
+
+| Token | Resolves to |
+|---|---|
+| `{username}` | local-part of email (before `@`) — e.g. `collinc` |
+| `{email}` / `{user_email}` | full email — e.g. `collinc@comet.com` |
+| `{user_uuid}` | Anthropic account UUID |
+| `{display_name}` | OAuth display name |
+| `{org_name}` | Anthropic organization name |
+| `{org_uuid}` | Anthropic organization UUID |
+
+Unknown tokens pass through literally so misconfigurations are visible in Opik rather than silently producing empty project names.
+
+Per-trace identity (`cc.identity.user_email`, `cc.identity.user_uuid`, `cc.identity.org_uuid`, etc.) is also attached to every trace's metadata regardless of project name, plus a `user:<email>` tag, so admins can filter/group across users in a shared project too.
+
 ## Configuration
 
 Run the Opik CLI to configure your connection:
@@ -56,7 +114,8 @@ This creates `~/.opik.config` with your API URL, key, and workspace.
 ### Optional Environment Variables
 
 ```bash
-export OPIK_CC_PROJECT="my-project"         # Project name (default: claude-code)
+export OPIK_CC_TRACING_ENABLED="true"       # Org-wide enable, useful from managed settings
+export OPIK_CC_PROJECT="my-project"         # Project name (default: claude-code); supports {field} tokens — see Enterprise Install
 export OPIK_CC_WORKSPACE="my-workspace"     # Workspace override (default: OPIK_WORKSPACE / ~/.opik.config)
 export OPIK_CC_TRUNCATE_FIELDS="false"      # Don't truncate large fields
 ```

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ For org-wide deployment, push configuration through [Claude Code's server-manage
     "OPIK_CC_WORKSPACE": "your-org-cc-workspace",
     "OPIK_API_KEY": "<workspace-scoped API key>",
     "OPIK_CC_PROJECT": "cc-{username}"
-  }
+  },
+  "forceRemoteSettingsRefresh": true,
+  "showThinkingSummaries": true
 }
 ```
 
@@ -78,6 +80,8 @@ What each piece does:
 - `OPIK_CC_WORKSPACE` — sends Claude Code traces to a dedicated workspace, isolated from any user's personal Opik work in `~/.opik.config`.
 - `OPIK_API_KEY` — the workspace-scoped key the hook uses to write traces. Treat this file as sensitive; the API key is shared with every machine it's deployed to. Provision a key with the minimum write scope on the CC workspace.
 - `OPIK_CC_PROJECT` — supports `{field}` tokens that expand from the user's Claude Code OAuth identity (read from `~/.claude.json`). So one config string routes every user to their own project.
+- `forceRemoteSettingsRefresh: true` — fail-closed startup: blocks the CLI at launch until fresh managed settings are fetched from Anthropic, so the brief unenforced window on first launch can't leak unmonitored sessions. Requires connectivity to `api.anthropic.com`.
+- `showThinkingSummaries: true` — surfaces extended-thinking summaries in the user's transcript so the same reasoning that gets traced to Opik is visible to the user locally. Optional but useful when you want what's logged to match what users see.
 
 **Available `{field}` tokens:**
 

--- a/README.md
+++ b/README.md
@@ -44,17 +44,11 @@ If you've cloned the repo locally, add it as a marketplace and install from ther
 
 ### Enterprise Install (Managed Settings)
 
-For org-wide deployment, drop a [Claude Code managed-settings.json](https://code.claude.com/docs/en/settings) on every user's machine via your MDM. Managed settings override user/project settings and let an admin enable the plugin, point it at an org-owned Opik workspace, and route every user to their own project automatically.
+For org-wide deployment, push configuration through [Claude Code's server-managed settings](https://code.claude.com/docs/en/server-managed-settings) — Anthropic's admin console delivers the JSON to every authenticated user, no file distribution or MDM required. (Requires Claude for Teams or Enterprise.)
 
-**Path on each platform:**
+**Where to set it up:** in [Claude.ai](https://claude.ai), go to **Admin Settings → Claude Code → Managed settings** and paste the JSON below. Clients pick it up at next startup or within the hourly poll.
 
-| Platform | Path |
-|---|---|
-| macOS | `/Library/Application Support/ClaudeCode/managed-settings.json` |
-| Linux/WSL | `/etc/claude-code/managed-settings.json` |
-| Windows | `C:\Program Files\ClaudeCode\managed-settings.json` |
-
-**Example `managed-settings.json`:**
+**Example managed settings JSON:**
 
 ```json
 {

--- a/src/config.go
+++ b/src/config.go
@@ -51,7 +51,9 @@ func LoadConfig() (*Config, error) {
 	// SDK. project_name is kept as a fallback for backward compatibility, but it
 	// is shared with the Opik SDK config in ~/.opik.config.
 	if proj := getEnvOrConfig("OPIK_CC_PROJECT", fileConfig, "cc_project_name"); proj != "" {
-		cfg.Project = proj
+		// {field} tokens resolve against Claude's OAuth identity so admins can
+		// route per-user projects (e.g. "cc-{username}") from managed settings.
+		cfg.Project = expandProjectTemplate(proj, loadClaudeIdentity())
 	} else if proj := fileConfig["project_name"]; proj != "" {
 		cfg.Project = proj
 	}
@@ -121,6 +123,12 @@ func getTracingState() tracingState {
 		}
 	}
 
+	// Org-wide enable/disable via managed settings env. Sits between project-
+	// level (explicit per-repo opt-out still wins) and user-level files.
+	if v := os.Getenv("OPIK_CC_TRACING_ENABLED"); v != "" {
+		return tracingState{enabled: strings.EqualFold(v, "true") || v == "1"}
+	}
+
 	// Fall back to a user-level marker so tracing can be enabled for all projects.
 	if homeDir, err := os.UserHomeDir(); err == nil && homeDir != "" {
 		if state, found := checkTracingFile(filepath.Join(homeDir, ".claude", ".opik-tracing-enabled")); found {
@@ -129,4 +137,30 @@ func getTracingState() tracingState {
 	}
 
 	return tracingState{}
+}
+
+// expandProjectTemplate substitutes {field} tokens in the project name from
+// the loaded Claude identity. Unknown tokens are left as-is so misconfigs are
+// visible in Opik instead of silently producing a half-empty name.
+func expandProjectTemplate(template string, id ClaudeIdentity) string {
+	if !strings.ContainsRune(template, '{') {
+		return template
+	}
+	username := id.Email
+	if at := strings.IndexByte(username, '@'); at > 0 {
+		username = username[:at]
+	}
+	replacements := map[string]string{
+		"{email}":        id.Email,
+		"{user_email}":   id.Email,
+		"{username}":     username,
+		"{user_uuid}":    id.UserUUID,
+		"{display_name}": id.DisplayName,
+		"{org_name}":     id.OrgName,
+		"{org_uuid}":     id.OrgUUID,
+	}
+	for token, value := range replacements {
+		template = strings.ReplaceAll(template, token, value)
+	}
+	return template
 }

--- a/src/config_test.go
+++ b/src/config_test.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestExpandProjectTemplate(t *testing.T) {
+	id := ClaudeIdentity{
+		UserUUID:    "uuid-123",
+		Email:       "collinc@comet.com",
+		DisplayName: "Collin",
+		OrgUUID:     "org-456",
+		OrgName:     "Comet",
+	}
+
+	cases := []struct {
+		name     string
+		template string
+		identity ClaudeIdentity
+		want     string
+	}{
+		{"no tokens passes through", "claude-code", id, "claude-code"},
+		{"username strips domain", "cc-{username}", id, "cc-collinc"},
+		{"full email token", "cc-{email}", id, "cc-collinc@comet.com"},
+		{"user_email alias", "cc-{user_email}", id, "cc-collinc@comet.com"},
+		{"user_uuid token", "{user_uuid}", id, "uuid-123"},
+		{"display_name token", "{display_name}", id, "Collin"},
+		{"org_name token", "{org_name}-cc", id, "Comet-cc"},
+		{"org_uuid token", "{org_uuid}", id, "org-456"},
+		{"multiple tokens compose", "{org_name}/{username}", id, "Comet/collinc"},
+		{"unknown token left as-is", "cc-{not_a_field}", id, "cc-{not_a_field}"},
+		{"email without @ uses full value", "cc-{username}", ClaudeIdentity{Email: "noatsign"}, "cc-noatsign"},
+		{"empty identity yields empty values", "cc-{username}-{email}", ClaudeIdentity{}, "cc--"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := expandProjectTemplate(tc.template, tc.identity)
+			if got != tc.want {
+				t.Errorf("expandProjectTemplate(%q) = %q, want %q", tc.template, got, tc.want)
+			}
+		})
+	}
+}
+
+// writeFile creates a file with the given content, failing the test on error.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGetTracingState(t *testing.T) {
+	// Build a fresh project + home dir per subtest so file fallbacks are
+	// deterministic and isolated. t.Setenv restores env after each subtest.
+	cases := []struct {
+		name        string
+		envVar      string // OPIK_CC_TRACING_ENABLED value; "" means unset
+		projectFile string // contents to write to <projectDir>/.claude/.opik-tracing-enabled, "" to skip
+		userFile    string // contents to write to <home>/.claude/.opik-tracing-enabled, "" to skip
+		wantEnabled bool
+	}{
+		{name: "env true enables", envVar: "true", wantEnabled: true},
+		{name: "env 1 enables", envVar: "1", wantEnabled: true},
+		{name: "env TRUE case insensitive", envVar: "TRUE", wantEnabled: true},
+		{name: "env false disables", envVar: "false", wantEnabled: false},
+		{name: "env 0 disables", envVar: "0", wantEnabled: false},
+		{name: "no signals defaults disabled", wantEnabled: false},
+		{name: "user file enables when env unset", userFile: "on", wantEnabled: true},
+		{name: "project file enables", projectFile: "on", wantEnabled: true},
+		{name: "project file off overrides env true", envVar: "true", projectFile: "off", wantEnabled: false},
+		{name: "project file off overrides user enable", projectFile: "off", userFile: "on", wantEnabled: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			projectDir := t.TempDir()
+			homeDir := t.TempDir()
+			t.Setenv("CLAUDE_PROJECT_DIR", projectDir)
+			t.Setenv("HOME", homeDir)
+			t.Setenv("OPIK_CC_TRACING_ENABLED", tc.envVar)
+
+			if tc.projectFile != "" {
+				writeFile(t, filepath.Join(projectDir, ".claude", ".opik-tracing-enabled"), tc.projectFile)
+			}
+			if tc.userFile != "" {
+				writeFile(t, filepath.Join(homeDir, ".claude", ".opik-tracing-enabled"), tc.userFile)
+			}
+
+			state := getTracingState()
+			if state.enabled != tc.wantEnabled {
+				t.Errorf("enabled = %v, want %v", state.enabled, tc.wantEnabled)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two new knobs so org admins can deploy Claude Code tracing across a whole org via [managed settings](https://code.claude.com/docs/en/settings) without touching each user's machine:

- **`OPIK_CC_TRACING_ENABLED`** — env-based enable/disable for tracing, slotted between project-level files (still wins for explicit per-repo opt-out via `off`) and user-level files. Lets managed-settings env turn tracing on globally while sensitive repos keep their opt-out.
- **`{field}` tokens in `OPIK_CC_PROJECT`** — substituted from the loaded `ClaudeIdentity`. Admins configure once (e.g. `cc-{username}`) and each user's traces land in their own project. Unknown tokens pass through literally so misconfigs surface in Opik instead of silently producing half-empty names.

Available tokens: `{email}`, `{user_email}`, `{username}` (email local-part), `{user_uuid}`, `{display_name}`, `{org_name}`, `{org_uuid}`.

### Example managed-settings.json

```json
{
  "enabledPlugins": {"opik@opik": true},
  "env": {
    "OPIK_CC_TRACING_ENABLED": "true",
    "OPIK_BASE_URL": "https://www.comet.com/opik/api",
    "OPIK_CC_WORKSPACE": "<org-cc-workspace>",
    "OPIK_API_KEY": "<workspace-scoped key>",
    "OPIK_CC_PROJECT": "cc-{username}"
  }
}
```

## Test plan
- [x] Unit tests for `expandProjectTemplate` (12 cases — token aliases, missing `@`, empty identity, unknown tokens pass through)
- [x] Unit tests for `getTracingState` (10 cases — env values, file fallbacks, project-level `off` overriding env enable)
- [x] Manual end-to-end via managed settings on macOS: confirmed trace lands in `cc-collinc` (project) under templated workspace
- [ ] Confirm CI workflow still builds release binaries cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)