### PR TITLE
Fix: write trace domain snapshots even outside a git work tree

### DIFF
--- a/src/metrics.go
+++ b/src/metrics.go
@@ -171,56 +171,56 @@ func captureCwdAndHead() (cwd, head string) {
 	return
 }
 
-// postTraceMetrics computes git-grounded metrics for the closing trace and
-// merges them into trace.metadata.cc. Feedback scores stay reserved for
-// evaluative judgments — task_class and summary — written by other workers.
+// postTraceMetrics computes per-trace metadata for the closing trace and
+// merges it into trace.metadata.cc. Git-grounded metrics are best-effort —
+// they only land when cwd is inside a git work tree — while the per-domain
+// transcript snapshots (skills, tools, memory, …) always run because they
+// read only the transcript and the user's filesystem, not git.
 func postTraceMetrics(state *State) {
 	cwd := state.Cwd
 	if cwd == "" {
 		cwd = inferCwd()
 	}
-	if cwd == "" {
-		debugLog("postTraceMetrics: no cwd")
-		return
-	}
-	if git(cwd, "rev-parse", "--is-inside-work-tree") != "true" {
-		debugLog("postTraceMetrics: %s is not a git work tree", cwd)
-		return
-	}
 
-	agg := aggregateEdits(state)
+	metrics := map[string]interface{}{}
 
-	repo := repoName(cwd)
-	branch := git(cwd, "branch", "--show-current")
-	// HEAD as of trace close; pairs with state.HeadSHAStart captured at onPrompt.
-	headEnd := git(cwd, "rev-parse", "HEAD")
-	commits, insC, delC := commitsBetween(cwd, state.HeadSHAStart, headEnd)
-	filesU, insU, delU := parseShortstat(git(cwd, "diff", "HEAD", "--shortstat"))
+	var repo, branch string
+	var commits, insC, delC int
+	var agg *EditAggregate
+	if cwd != "" && git(cwd, "rev-parse", "--is-inside-work-tree") == "true" {
+		agg = aggregateEdits(state)
 
-	gitMetrics := map[string]interface{}{
-		"commits_in_trace":  commits,
-		"lines_committed":   insC + delC,
-		"uncommitted_lines": insU + delU,
-		"uncommitted_files": filesU,
-		"files_authored":    len(agg.Files),
-		"lines_authored":    agg.LinesAuthored,
-		"lines_overwritten": agg.LinesOverwritten,
-	}
-	if repo != "" {
-		gitMetrics["repository"] = repo
-	}
-	if branch != "" {
-		gitMetrics["branch"] = branch
-	}
-	if state.HeadSHAStart != "" {
-		gitMetrics["head_sha_start"] = shortSHA(state.HeadSHAStart)
-	}
-	if headEnd != "" {
-		gitMetrics["head_sha_end"] = shortSHA(headEnd)
-	}
+		repo = repoName(cwd)
+		branch = git(cwd, "branch", "--show-current")
+		// HEAD as of trace close; pairs with state.HeadSHAStart captured at onPrompt.
+		headEnd := git(cwd, "rev-parse", "HEAD")
+		commits, insC, delC = commitsBetween(cwd, state.HeadSHAStart, headEnd)
+		filesU, insU, delU := parseShortstat(git(cwd, "diff", "HEAD", "--shortstat"))
 
-	metrics := map[string]interface{}{
-		"git": gitMetrics,
+		gitMetrics := map[string]interface{}{
+			"commits_in_trace":  commits,
+			"lines_committed":   insC + delC,
+			"uncommitted_lines": insU + delU,
+			"uncommitted_files": filesU,
+			"files_authored":    len(agg.Files),
+			"lines_authored":    agg.LinesAuthored,
+			"lines_overwritten": agg.LinesOverwritten,
+		}
+		if repo != "" {
+			gitMetrics["repository"] = repo
+		}
+		if branch != "" {
+			gitMetrics["branch"] = branch
+		}
+		if state.HeadSHAStart != "" {
+			gitMetrics["head_sha_start"] = shortSHA(state.HeadSHAStart)
+		}
+		if headEnd != "" {
+			gitMetrics["head_sha_end"] = shortSHA(headEnd)
+		}
+		metrics["git"] = gitMetrics
+	} else {
+		debugLog("postTraceMetrics: skipping git block (cwd=%q not a git work tree)", cwd)
 	}
 
 	fullEntries, _ := ReadTranscript(state.Transcript, 0)
@@ -231,10 +231,18 @@ func postTraceMetrics(state *State) {
 		}
 	}
 
+	if len(metrics) == 0 {
+		return
+	}
+
 	mergeMetadataCC(state.TraceID, metrics)
 
-	debugLog("metrics %s  repo=%s  branch=%s  commits=%d  +-=%d  uncommitted=%d  files=%d  authored=%d  overwritten=%d",
-		state.TraceID[:8], repo, branch, commits, insC+delC, insU+delU, len(agg.Files), agg.LinesAuthored, agg.LinesOverwritten)
+	var files, authored, overwritten int
+	if agg != nil {
+		files, authored, overwritten = len(agg.Files), agg.LinesAuthored, agg.LinesOverwritten
+	}
+	debugLog("metrics %s  repo=%s  branch=%s  commits=%d  +-=%d  files=%d  authored=%d  overwritten=%d  domains=%d",
+		state.TraceID[:8], repo, branch, commits, insC+delC, files, authored, overwritten, len(metrics))
 }
 
 


### PR DESCRIPTION
## Summary

`postTraceMetrics` writes the trace-level `cc.<domain>` blocks (skills, tools, memory, thinking, tool_results, user_prompts, file_attachments, prior_assistant, assistant_text) for every closing trace. It also writes a `cc.git` block when the current working directory is a git work tree. Today the function bails out *entirely* if cwd is not a git work tree, dropping all nine domain snapshots even though none of them touch git.

## Repro

Launch Claude Code from a non-repo parent directory (e.g. \`~/code\` used as a holder for many sibling repos). Send any prompt with tracing enabled. The resulting Opik trace shows:

- ✅ \`cc.identity\` (written by \`identity.applyToTrace\` at trace creation)
- ✅ per-span \`cc.llm_call\` (written in the span loop)
- ❌ \`cc.skills\`, \`cc.tools\`, \`cc.memory\`, … (missing — \`postTraceMetrics\` returned at the git check)

Debug log signature: \`postTraceMetrics: <cwd> is not a git work tree\`

## Fix

Move the git work-tree check inline so it gates only the git block. Domain snapshots always run; the final PATCH is skipped only when both produced nothing.

## Test plan
- [x] Verified locally: ran CC from \`/Users/collinc/code\` (non-git), confirmed the closing trace now carries \`cc.skills\` and \`cc.tools\` alongside \`cc.identity\` — git block correctly absent
- [x] \`go vet ./src\` clean
- [x] Existing unit tests pass (\`go test ./src/...\`)
- [ ] Sanity-check inside a real repo to confirm git block still writes when available

🤖 Generated with [Claude Code](https://claude.com/claude-code)