### PR TITLE
ci: include the version in the release run title

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
 name: Release
+run-name: Release v${{ inputs.version }}
 
 # Manually triggered from the Actions tab (or `gh workflow run release.yml -f version=0.3.1`).
 # Bumps the version, rebuilds binaries, commits both to main, tags, and publishes


### PR DESCRIPTION
## Details

Adds `run-name: Release v${{ inputs.version }}` to the release workflow so manually dispatched runs show the version in the Actions UI run list instead of the bare workflow name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)