### PR TITLE
[codex] Fix hook flush overhead

### DIFF
--- a/src/count_tokens.go
+++ b/src/count_tokens.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"os"
 	"os/exec"
@@ -238,6 +239,9 @@ var countTokensHTTP = func(payload []byte, headers map[string]string) (int, erro
 		return 0, err
 	}
 	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return 0, fmt.Errorf("count_tokens: %s", resp.Status)
+	}
 	var out struct {
 		InputTokens int `json:"input_tokens"`
 	}

--- a/src/count_tokens_test.go
+++ b/src/count_tokens_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"strings"
 	"testing"
@@ -108,6 +109,26 @@ func TestRunTokenCountPassBudgetAndBaseline(t *testing.T) {
 		t.Error("second pass should measure the remaining miss")
 	}
 	_ = spent
+}
+
+func TestRunTokenCountPassDoesNotCacheHTTPError(t *testing.T) {
+	resetTokenCache(t)
+	t.Setenv("ANTHROPIC_API_KEY", "test-key")
+
+	old := countTokensHTTP
+	countTokensHTTP = func(payload []byte, headers map[string]string) (int, error) {
+		return 0, errors.New("count_tokens: 401 Unauthorized")
+	}
+	defer func() { countTokensHTTP = old }()
+
+	text := strings.Repeat("uncached prompt body\n", 20)
+	entries := []TranscriptEntry{userPromptEntry(text)}
+	if spent := runTokenCountPass(entries, 2); spent != 0 {
+		t.Fatalf("spent = %d, want 0 after HTTP error", spent)
+	}
+	if _, ok := tokenCacheGet(defaultCountModel + "|" + sha256hex(text)); ok {
+		t.Error("failed count_tokens response should not populate cache")
+	}
 }
 
 func jsonReadFile(path string) ([]byte, error) {

--- a/src/dryrun_test.go
+++ b/src/dryrun_test.go
@@ -120,6 +120,15 @@ func TestTraceNameResolution(t *testing.T) {
 	}
 }
 
+func TestSpansHaveUsage(t *testing.T) {
+	if spansHaveUsage([]Span{{Name: "Read"}, {Name: "Edit"}}) {
+		t.Fatal("tool-only spans should not require context snapshot work")
+	}
+	if !spansHaveUsage([]Span{{Name: "Thinking", Usage: map[string]int{"total_tokens": 12}}}) {
+		t.Fatal("LLM spans with usage should require context snapshot work")
+	}
+}
+
 // TestToolResultDebug enumerates every tool_use → tool_result pair and
 // flags any tool_use whose result the extractor isn't seeing.
 func TestToolResultDebug(t *testing.T) {

--- a/src/main.go
+++ b/src/main.go
@@ -622,13 +622,15 @@ func flush(state *State) {
 	// billed tokens to categories with a single-row query, no JOIN back
 	// to trace.cc.context_runtime. See context_snapshot.go for the
 	// accuracy tradeoff.
-	if snapshot := buildContextSnapshot(state); snapshot != nil {
-		for i := range spans {
-			if spans[i].Usage == nil {
-				continue
+	if spansHaveUsage(spans) {
+		if snapshot := buildContextSnapshot(state); snapshot != nil {
+			for i := range spans {
+				if spans[i].Usage == nil {
+					continue
+				}
+				cc := ensureCCMap(&spans[i])
+				cc["context_snapshot"] = snapshot
 			}
-			cc := ensureCCMap(&spans[i])
-			cc["context_snapshot"] = snapshot
 		}
 	}
 
@@ -636,6 +638,15 @@ func flush(state *State) {
 	if err := api.Post("/spans/batch", SpanBatch{Spans: spans}); err != nil {
 		debugLog("send spans: %v", err)
 	}
+}
+
+func spansHaveUsage(spans []Span) bool {
+	for _, span := range spans {
+		if span.Usage != nil {
+			return true
+		}
+	}
+	return false
 }
 
 // findSlug returns the best per-session identifier available on the

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -15,15 +15,10 @@ type EditAggregate struct {
 	LinesOverwritten int
 }
 
-// aggregateEdits walks transcript entries from state.StartLine forward and
-// returns counts for Edit/Write/MultiEdit tool calls Claude made in this trace.
-func aggregateEdits(state *State) *EditAggregate {
+// aggregateEdits walks transcript entries and returns counts for
+// Edit/Write/MultiEdit tool calls Claude made in this trace.
+func aggregateEdits(entries []TranscriptEntry) *EditAggregate {
 	agg := &EditAggregate{Files: map[string]struct{}{}}
-	entries, err := ReadTranscript(state.Transcript, state.StartLine)
-	if err != nil {
-		return agg
-	}
-
 	for _, entry := range entries {
 		if entry.Type != "assistant" || entry.Message == nil {
 			continue
@@ -184,12 +179,14 @@ func postTraceMetrics(state *State) {
 	}
 
 	metrics := map[string]interface{}{}
+	fullEntries, _ := ReadTranscript(state.Transcript, 0)
+	turnEntries, _ := ReadTranscript(state.Transcript, state.StartLine)
 
 	var repo, branch string
 	var commits, insC, delC int
 	var agg *EditAggregate
 	if cwd != "" && git(cwd, "rev-parse", "--is-inside-work-tree") == "true" {
-		agg = aggregateEdits(state)
+		agg = aggregateEdits(turnEntries)
 
 		repo = repoName(cwd)
 		branch = git(cwd, "branch", "--show-current")
@@ -224,8 +221,6 @@ func postTraceMetrics(state *State) {
 		debugLog("postTraceMetrics: skipping git block (cwd=%q not a git work tree)", cwd)
 	}
 
-	fullEntries, _ := ReadTranscript(state.Transcript, 0)
-	turnEntries, _ := ReadTranscript(state.Transcript, state.StartLine)
 	for domain, snap := range domainSnapshotsFromEntries(fullEntries, turnEntries) {
 		if snap != nil {
 			metrics[domain] = snap


### PR DESCRIPTION
## Summary

- Skip synchronous context snapshot construction when a flush batch contains only tool spans, avoiding full-transcript and filesystem scans that cannot be attached to any LLM usage span.
- Reuse the already-read turn transcript when computing close-out edit metrics, removing one duplicate transcript pass on Stop/SessionEnd.
- Treat non-2xx `count_tokens` responses as errors so the detached measurement pass does not cache zero-token anchors from auth/rate-limit/error payloads.

## Review notes

Recent changes added useful billing and attribution detail, but the hook hot path had one avoidable cost: `flush` always called `buildContextSnapshot`, even for tool-only batches. That helper reads the full transcript and hits memory/agent/skill/tool extractors; doing that during ordinary tool hook flushes slows Claude Code without adding metadata because only spans with usage receive the snapshot.

I did not include the local `bin/opik-logger-darwin-arm64` modification in this PR; it was already dirty before the source edits and looks like a local build artifact.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`
