### PR TITLE
[codex] Fix billing catalog attribution

### DIFF
--- a/src/billing.go
+++ b/src/billing.go
@@ -333,42 +333,6 @@ func conversationPieces(entries []TranscriptEntry, skillBodyNames map[string]str
 					}
 					add("file_attachments", ext, kindUsage, float64(tokEstimate(w.File.Content)), false)
 				}
-			case "deferred_tools_delta":
-				// The deferred catalog mixes built-in tool names with MCP
-				// ones — split so each lands in its lane (built-in names are
-				// part of Claude Code's own overhead, not MCP rent).
-				lines := e.Attachment.AddedLines
-				names := e.Attachment.AddedNames
-				if len(lines) != len(names) {
-					lines = names // fall back to names-only sizing
-				}
-				var builtinPayload, mcpPayload []string
-				for i, name := range names {
-					line := name
-					if i < len(lines) {
-						line = lines[i]
-					}
-					if strings.HasPrefix(name, "mcp__") {
-						mcpPayload = append(mcpPayload, line)
-					} else {
-						builtinPayload = append(builtinPayload, line)
-					}
-				}
-				add("static_overhead", "deferred_tool_names", kindDefinition,
-					float64(measuredOrEstimate(strings.Join(builtinPayload, "\n"), "deferred_tools_payload")), false)
-				add("mcp_servers", "catalog_deltas", kindDefinition,
-					float64(measuredOrEstimate(strings.Join(mcpPayload, "\n"), "deferred_tools_payload")), false)
-			case "mcp_instructions_delta":
-				// Per-server when the parallel arrays line up.
-				if len(e.Attachment.AddedNames) == len(e.Attachment.AddedBlocks) && len(e.Attachment.AddedNames) > 0 {
-					for i, name := range e.Attachment.AddedNames {
-						add("mcp_servers", name, kindDefinition,
-							float64(measuredOrEstimate(e.Attachment.AddedBlocks[i], "prose")), false)
-					}
-				} else {
-					add("mcp_servers", "instructions", kindDefinition,
-						float64(tokEstimateAs(strings.Join(e.Attachment.AddedBlocks, "\n"), "prose")), false)
-				}
 			}
 		case "assistant":
 			if e.Message == nil || len(e.Message.Content) == 0 {

--- a/src/billing_test.go
+++ b/src/billing_test.go
@@ -239,12 +239,15 @@ func TestDeferredCatalogSplitsBuiltinFromMcp(t *testing.T) {
 	soItems := lanes["static_overhead"].(map[string]interface{})["items"].([]map[string]interface{})
 	foundBuiltin := false
 	for _, it := range soItems {
-		if it["name"] == "deferred_tool_names" && it["total"].(int) > 0 {
+		if it["name"] == "observed_builtin_schemas" && it["total"].(int) > 0 {
 			foundBuiltin = true
+		}
+		if it["name"] == "deferred_tool_names" {
+			t.Errorf("deferred tool delta should not be replayed separately: %v", soItems)
 		}
 	}
 	if !foundBuiltin {
-		t.Errorf("expected deferred_tool_names under static_overhead: %v", soItems)
+		t.Errorf("expected observed_builtin_schemas under static_overhead: %v", soItems)
 	}
 	mcp, ok := lanes["mcp_servers"].(map[string]interface{})
 	if !ok {
@@ -252,12 +255,15 @@ func TestDeferredCatalogSplitsBuiltinFromMcp(t *testing.T) {
 	}
 	foundMcp := false
 	for _, it := range mcp["items"].([]map[string]interface{}) {
-		if it["name"] == "catalog_deltas" && it["total"].(int) > 0 {
+		if it["name"] == "slack" && it["total"].(int) > 0 {
 			foundMcp = true
+		}
+		if it["name"] == "catalog_deltas" {
+			t.Errorf("MCP catalog delta should not be replayed separately: %v", mcp["items"])
 		}
 	}
 	if !foundMcp {
-		t.Errorf("expected catalog_deltas under mcp_servers: %v", mcp["items"])
+		t.Errorf("expected slack server under mcp_servers: %v", mcp["items"])
 	}
 }
 

--- a/src/metrics.go
+++ b/src/metrics.go
@@ -322,7 +322,7 @@ func postReconciliationScore(traceID string, billing interface{}) {
 			recon["cache_creation_delta"], recon["output_delta"])
 	}
 
-	if err := api.Put("/traces/feedback-scores", map[string]interface{}{
+	if err := api.Post("/traces/feedback-scores", map[string]interface{}{
 		"scores": []interface{}{score},
 	}); err != nil {
 		debugLog("post reconciliation score: %v", err)


### PR DESCRIPTION
## Summary

- Stop replaying `deferred_tools_delta` and `mcp_instructions_delta` attachment rows as separate billing pieces after the tool catalog has already been reconstructed in the static prefix.
- Update the deferred catalog regression test to assert the single static-prefix representation and guard against the old duplicate delta items.
- Send `token_count_consistent` feedback scores with `POST /traces/feedback-scores`, matching the documented Opik endpoint.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`
