### PR TITLE
[codex] Limit foreground API timeout

### DIFF
--- a/src/api.go
+++ b/src/api.go
@@ -14,10 +14,19 @@ type API struct {
 	client *http.Client
 }
 
+const (
+	foregroundAPITimeout = 2 * time.Second
+	backgroundAPITimeout = 30 * time.Second
+)
+
 func NewAPI(cfg *Config) *API {
+	return NewAPIWithTimeout(cfg, foregroundAPITimeout)
+}
+
+func NewAPIWithTimeout(cfg *Config, timeout time.Duration) *API {
 	return &API{
 		config: cfg,
-		client: &http.Client{Timeout: 30 * time.Second},
+		client: &http.Client{Timeout: timeout},
 	}
 }
 

--- a/src/api_test.go
+++ b/src/api_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"testing"
+	"time"
+)
+
+func TestAPITimeouts(t *testing.T) {
+	if got := NewAPI(&Config{}).client.Timeout; got != 2*time.Second {
+		t.Errorf("foreground timeout = %s, want 2s", got)
+	}
+	if got := NewAPIWithTimeout(&Config{}, backgroundAPITimeout).client.Timeout; got != 30*time.Second {
+		t.Errorf("background timeout = %s, want 30s", got)
+	}
+}

--- a/src/main.go
+++ b/src/main.go
@@ -63,7 +63,7 @@ func main() {
 		if err != nil || config == nil {
 			os.Exit(0)
 		}
-		api = NewAPI(config)
+		api = NewAPIWithTimeout(config, backgroundAPITimeout)
 		runContextFetchMode()
 		os.Exit(0)
 	}


### PR DESCRIPTION
## Summary

- Reduce foreground hook Opik API timeout from 30s to 2s so Claude Code does not wait tens of seconds when Opik is unreachable.
- Add an explicit API constructor for longer background calls and keep the detached `/context` worker on the 30s timeout.
- Cover the timeout split with a small unit test.

## Validation

- `go test ./...`
- `go vet ./...`
- `git diff --check`
